### PR TITLE
Inline bot detection assets into HTML pages

### DIFF
--- a/bot_server.py
+++ b/bot_server.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Kleiner HTTP-Server mit grundlegender Bot-Erkennung."""
+
+from __future__ import annotations
+
+import json
+import logging
+import textwrap
+import time
+from http import HTTPStatus
+from http.cookies import SimpleCookie
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from typing import Dict, List
+from urllib.parse import unquote
+
+BASE_DIR = Path(__file__).resolve().parent
+WEB_DIR = BASE_DIR / "web"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+)
+
+
+class SuspicionStore:
+    """Speichert Verdachtsfälle in Memory."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, List[str]]] = {}
+
+    def flag(self, client_id: str, reason: str) -> None:
+        bucket = self._store.setdefault(client_id, {"reasons": [], "ts": time.time()})
+        if reason not in bucket["reasons"]:
+            bucket["reasons"].append(reason)
+            bucket["ts"] = time.time()
+
+    def bulk_flag(self, client_id: str, reasons: List[str]) -> None:
+        for reason in reasons:
+            self.flag(client_id, reason)
+
+    def get(self, client_id: str) -> Dict[str, List[str]] | None:
+        entry = self._store.get(client_id)
+        if entry and time.time() - entry.get("ts", 0) > 3600:
+            # nach einer Stunde löschen
+            self._store.pop(client_id, None)
+            return None
+        return entry
+
+
+SUSPICIOUS_TOKENS = ("bot", "spider", "crawler", "scrapy", "curl", "python")
+HEADLESS_HINTS = ("headless", "phantomjs", "selenium")
+
+
+class BotShieldHandler(SimpleHTTPRequestHandler):
+    suspicion_store = SuspicionStore()
+
+    def translate_path(self, path: str) -> str:
+        """Sicherstellen, dass nur Dateien aus dem Web-Ordner bedient werden."""
+        clean_path = unquote(path.split("?", 1)[0].split("#", 1)[0])
+        target = (WEB_DIR / clean_path.lstrip("/")).resolve()
+        if target.is_dir():
+            target = target / "index.html"
+        try:
+            target.relative_to(WEB_DIR)
+        except ValueError:
+            return str(WEB_DIR / "index.html")
+        if not target.exists():
+            return str(WEB_DIR / "index.html")
+        return str(target)
+
+    # pylint: disable=missing-docstring
+    def log_message(self, format: str, *args):  # type: ignore[override]
+        logging.info("%s - %s", self.client_address[0], format % args)
+
+    def end_headers(self):  # type: ignore[override]
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    def do_GET(self) -> None:  # type: ignore[override]
+        client_id = self.client_address[0]
+        if self.path == "/bot-status":
+            self._handle_status(client_id)
+            return
+
+        suspicious_reasons = self._analyse_request()
+        if suspicious_reasons:
+            logging.warning("Verdächtige Anfrage von %s: %s", client_id, suspicious_reasons)
+            self.suspicion_store.bulk_flag(client_id, suspicious_reasons)
+            self._deny_request(client_id, suspicious_reasons)
+            return
+
+        stored = self.suspicion_store.get(client_id)
+        if stored:
+            self._deny_request(client_id, stored["reasons"])
+            return
+
+        super().do_GET()
+
+    def do_POST(self) -> None:  # type: ignore[override]
+        client_id = self.client_address[0]
+        if self.path != "/report-bot":
+            self.send_error(HTTPStatus.NOT_FOUND, "Unbekannte Ressource")
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = self.rfile.read(length).decode("utf-8") if length else "{}"
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Ungültiges JSON")
+            return
+
+        reasons = data.get("reasons") or []
+        if isinstance(reasons, list):
+            for reason in reasons:
+                if isinstance(reason, str) and reason.strip():
+                    self.suspicion_store.flag(client_id, reason.strip())
+        logging.warning("Client %s meldete verdächtiges Verhalten: %s", client_id, reasons)
+
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"status": "received"}).encode("utf-8"))
+
+    # Hilfsfunktionen -----------------------------------------------------
+
+    def _analyse_request(self) -> List[str]:
+        reasons: List[str] = []
+        user_agent = (self.headers.get("User-Agent") or "").lower()
+        if not user_agent:
+            reasons.append("Kein User-Agent")
+        else:
+            if any(token in user_agent for token in SUSPICIOUS_TOKENS):
+                reasons.append("User-Agent enthält Bot-Tokens")
+            if any(token in user_agent for token in HEADLESS_HINTS):
+                reasons.append("Headless-Indiz im User-Agent")
+        if not self.headers.get("Accept-Language"):
+            reasons.append("Keine Accept-Language gesetzt")
+        fetch_site = self.headers.get("Sec-Fetch-Site")
+        if fetch_site == "none":
+            reasons.append("Fehlender Kontext (Sec-Fetch-Site: none)")
+        if self.headers.get("X-Forwarded-For"):
+            reasons.append("Proxy/Forwarded Header gesetzt")
+        return reasons
+
+    def _deny_request(self, client_id: str, reasons: List[str]) -> None:
+        body = textwrap.dedent(
+            """
+            <html lang='de'>
+              <head>
+                <meta charset='utf-8' />
+                <title>Zugriff blockiert</title>
+                <style>
+                  body {
+                    font-family: Arial, sans-serif;
+                    background: #0f172a;
+                    color: #fff;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    height: 100vh;
+                    margin: 0;
+                  }
+                  main {
+                    background: rgba(15, 23, 42, 0.85);
+                    padding: 2.5rem;
+                    border-radius: 20px;
+                    max-width: 640px;
+                    box-shadow: 0 24px 64px rgba(15, 23, 42, 0.5);
+                  }
+                  h1 {
+                    margin-top: 0;
+                    color: #f97316;
+                  }
+                  li {
+                    margin-bottom: 0.5rem;
+                  }
+                  code {
+                    background: rgba(15, 23, 42, 0.6);
+                    padding: 0.1rem 0.4rem;
+                    border-radius: 6px;
+                  }
+                </style>
+              </head>
+              <body>
+                <main>
+                  <h1>Zugriff verweigert</h1>
+                  <p>Die Anfrage wurde als potenzieller Bot identifiziert. Gründe:</p>
+                  <ul>
+            """
+        ).strip()
+        body += "".join(f"<li>{reason}</li>\n" for reason in reasons)
+        body += textwrap.dedent(
+            """
+                  </ul>
+                  <p>Bitte kontaktiere den Support, wenn du glaubst, dass dies ein Fehler ist.</p>
+                  <p><code>/bot-status</code> liefert detaillierte Informationen.</p>
+                </main>
+              </body>
+            </html>
+            """
+        )
+        cookie = SimpleCookie()
+        cookie["bot_flagged"] = "1"
+        cookie["bot_flagged"]["path"] = "/"
+        encoded_body = body.encode("utf-8")
+        self.send_response(HTTPStatus.FORBIDDEN)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded_body)))
+        for morsel in cookie.values():
+            self.send_header("Set-Cookie", morsel.OutputString())
+        self.end_headers()
+        self.wfile.write(encoded_body)
+
+    def _handle_status(self, client_id: str) -> None:
+        stored = self.suspicion_store.get(client_id)
+        payload = {"flagged": False, "reasons": []}
+        if stored:
+            payload["flagged"] = True
+            payload["reasons"] = stored["reasons"]
+        cookie_header = self.headers.get("Cookie")
+        if cookie_header:
+            cookie = SimpleCookie()
+            cookie.load(cookie_header)
+            if cookie.get("bot_flagged"):
+                payload.setdefault("cookies", {})
+                payload["cookies"]["bot_flagged"] = cookie["bot_flagged"].value
+
+        response = json.dumps(payload)
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response.encode("utf-8"))
+
+
+def run(server_class=HTTPServer, handler_class=BotShieldHandler) -> None:
+    server_address = ("0.0.0.0", 8080)
+    httpd = server_class(server_address, handler_class)
+    logging.info("BotShield-Server läuft auf http://%s:%s", *server_address)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        logging.info("Server wird beendet ...")
+    finally:
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    run()

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,425 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HumanShield – Startseite</title>
+    <style>
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  --accent: #2563eb;
+  --danger: #dc2626;
+  --surface: rgba(255, 255, 255, 0.86);
+  --surface-dark: rgba(17, 24, 39, 0.86);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e3a8a, #0f172a);
+  color: #f8fafc;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.site-header {
+  padding: 1.5rem 2rem;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-header nav {
+  display: flex;
+  gap: 1rem;
+  font-weight: 600;
+}
+
+.content {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 24px;
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.35);
+}
+
+.content h2,
+.content h3 {
+  color: #e0f2fe;
+}
+
+.content ul {
+  padding-left: 1.25rem;
+}
+
+.content details {
+  margin-bottom: 1rem;
+  background: rgba(30, 58, 138, 0.45);
+  padding: 1rem;
+  border-radius: 12px;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.78);
+  backdrop-filter: blur(4px);
+  transition: opacity 0.25s ease;
+  z-index: 999;
+}
+
+.overlay.hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.overlay-card {
+  width: min(420px, 90vw);
+  background: var(--surface);
+  color: #0f172a;
+  padding: 2rem;
+  border-radius: 16px;
+  box-shadow: 0 16px 48px rgba(15, 23, 42, 0.3);
+}
+
+@media (prefers-color-scheme: dark) {
+  .overlay-card {
+    background: var(--surface-dark);
+    color: #f1f5f9;
+  }
+}
+
+.overlay-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.overlay-card input {
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  font-size: 1rem;
+}
+
+.overlay-card button {
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  background: var(--accent);
+  color: white;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.overlay-card button:hover,
+.overlay-card button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 24px rgba(37, 99, 235, 0.4);
+}
+
+.alert {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 1.5rem;
+  margin-inline: auto;
+  width: min(480px, 90vw);
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+  background: rgba(220, 38, 38, 0.9);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
+  z-index: 1000;
+}
+
+.alert.hidden {
+  display: none;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+    </style>
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>HumanShield</h1>
+      <nav>
+        <a href="index.html">Start</a>
+        <a href="support.html">Support</a>
+      </nav>
+    </header>
+
+    <main class="content" data-page-id="home">
+      <section>
+        <h2>Bot-Erkennung für jede Seite</h2>
+        <p>
+          Diese Demo zeigt, wie mehrere Signale kombiniert werden können, um
+          automatisierte Zugriffe abzuwehren. Jeder Seitenaufruf aktiviert den
+          HumanShield-Check und fordert Besucher zu einer kurzen
+          Interaktions-Prüfung auf.
+        </p>
+      </section>
+
+      <section>
+        <h3>Was geprüft wird</h3>
+        <ul>
+          <li>Ungewöhnliche Browser-Kennungen und Headless-Merkmale</li>
+          <li>Fehlende Eingabegeräte oder Interaktion</li>
+          <li>Sehr schnelle Formular-Antworten</li>
+          <li>Falsche Antworten auf dynamische Wissensfragen</li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Integration</h3>
+        <p>
+          Die Python-Server-Komponente reagiert auf gemeldete Verdachtsmomente
+          und kann flexibel erweitert werden, um IP-Adressen zu blockieren oder
+          zusätzliche Logik einzubinden.
+        </p>
+      </section>
+    </main>
+
+    <div id="challenge-overlay" class="overlay hidden">
+      <div class="overlay-card">
+        <h2>Interaktionsprüfung</h2>
+        <p id="challenge-text"></p>
+        <form id="challenge-form">
+          <label class="visually-hidden" for="challenge-answer">Antwort</label>
+          <input
+            id="challenge-answer"
+            type="text"
+            name="answer"
+            autocomplete="off"
+            required
+          />
+          <button type="submit">Antwort prüfen</button>
+        </form>
+        <p id="challenge-feedback" aria-live="polite"></p>
+      </div>
+    </div>
+
+    <div id="alert-banner" class="alert hidden" role="alert"></div>
+    <script>
+(function () {
+  const overlay = document.getElementById("challenge-overlay");
+  const challengeText = document.getElementById("challenge-text");
+  const challengeForm = document.getElementById("challenge-form");
+  const challengeAnswer = document.getElementById("challenge-answer");
+  const challengeFeedback = document.getElementById("challenge-feedback");
+  const alertBanner = document.getElementById("alert-banner");
+  const pageId = document.querySelector("main.content")?.dataset.pageId ?? "unknown";
+
+  const suspiciousSignals = new Set();
+  let questionStart = performance.now();
+  let currentQuestion = null;
+  let hasReported = false;
+  let interactionDetected = false;
+
+  const questions = [
+    {
+      text: "Schreibe die letzten drei Buchstaben des Wortes 'Verifikation' rückwärts.",
+      validate: (answer) =>
+        answer.trim().toLowerCase() === "noitacifirev".slice(-3).split("").reverse().join(""),
+    },
+    {
+      text: "Welche Zahl ergibt 7×3 minus 4?",
+      validate: (answer) => Number.parseInt(answer, 10) === 17,
+    },
+    {
+      text: "Tippe das zweite Wort dieses Satzes: 'Bots lösen selten Rätsel'.",
+      validate: (answer) => answer.trim().toLowerCase() === "lösen",
+    },
+    {
+      text: "Gib die Summe der Zahlen 4, 6 und 9 an.",
+      validate: (answer) => Number.parseInt(answer, 10) === 19,
+    },
+    {
+      text: "Schreibe das Wort 'Mensch' ohne den ersten Buchstaben.",
+      validate: (answer) => answer.trim().toLowerCase() === "ensch",
+    },
+  ];
+
+  function showOverlay() {
+    overlay?.classList.remove("hidden");
+    challengeAnswer?.focus({ preventScroll: true });
+  }
+
+  function hideOverlay() {
+    overlay?.classList.add("hidden");
+    challengeFeedback.textContent = "";
+  }
+
+  function pickQuestion() {
+    currentQuestion = questions[Math.floor(Math.random() * questions.length)];
+    questionStart = performance.now();
+    if (challengeText) {
+      challengeText.textContent = currentQuestion.text;
+    }
+    challengeAnswer.value = "";
+    showOverlay();
+  }
+
+  function markSuspicious(reason) {
+    if (!reason || suspiciousSignals.has(reason)) {
+      return;
+    }
+    suspiciousSignals.add(reason);
+    alertBanner.textContent = `Verdächtiges Verhalten erkannt: ${reason}`;
+    alertBanner.classList.remove("hidden");
+    reportSuspicion();
+  }
+
+  async function reportSuspicion() {
+    if (hasReported || suspiciousSignals.size === 0) {
+      return;
+    }
+    hasReported = true;
+    try {
+      const response = await fetch("/report-bot", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          page: pageId,
+          reasons: Array.from(suspiciousSignals),
+          timestamp: new Date().toISOString(),
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`Server meldete Status ${response.status}`);
+      }
+    } catch (error) {
+      console.error("Bot-Report fehlgeschlagen", error);
+    }
+  }
+
+  function analyseBrowser() {
+    const ua = navigator.userAgent.toLowerCase();
+    if (!ua) {
+      markSuspicious("User-Agent fehlt");
+    }
+    const suspiciousTokens = ["bot", "spider", "crawler", "scrapy", "curl", "python"];
+    if (suspiciousTokens.some((token) => ua.includes(token))) {
+      markSuspicious("Verdächtiger User-Agent");
+    }
+    if (navigator.webdriver) {
+      markSuspicious("Webdriver aktiv");
+    }
+    if (!navigator.languages || navigator.languages.length === 0) {
+      markSuspicious("Keine Sprache konfiguriert");
+    }
+    if (window.outerWidth === 0 || window.outerHeight === 0) {
+      markSuspicious("Fenstergröße ungewöhnlich");
+    }
+    if (!("onmousemove" in window) && !("ontouchstart" in window)) {
+      markSuspicious("Keine Zeiger- oder Touch-Events");
+    }
+  }
+
+  function setupInteractionWatchdog() {
+    const interactionHandler = () => {
+      interactionDetected = true;
+      window.removeEventListener("mousemove", interactionHandler);
+      window.removeEventListener("touchstart", interactionHandler);
+      window.removeEventListener("keydown", interactionHandler);
+    };
+
+    window.addEventListener("mousemove", interactionHandler, { once: true });
+    window.addEventListener("touchstart", interactionHandler, { once: true });
+    window.addEventListener("keydown", interactionHandler, { once: true });
+
+    setTimeout(() => {
+      if (!interactionDetected) {
+        markSuspicious("Keine Benutzerinteraktion innerhalb von 8s");
+      }
+    }, 8000);
+  }
+
+  async function fetchServerStatus() {
+    try {
+      const response = await fetch("/bot-status");
+      if (!response.ok) {
+        return;
+      }
+      const payload = await response.json();
+      if (payload?.flagged) {
+        alertBanner.textContent = `Server meldet Verdacht: ${payload.reasons.join(", ")}`;
+        alertBanner.classList.remove("hidden");
+      }
+    } catch (error) {
+      console.warn("Status konnte nicht geladen werden", error);
+    }
+  }
+
+  if (challengeForm) {
+    challengeForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      if (!currentQuestion) {
+        return;
+      }
+      const responseTime = performance.now() - questionStart;
+      const answer = challengeAnswer.value;
+      if (!currentQuestion.validate(answer)) {
+        challengeFeedback.textContent = "Antwort falsch. Bitte erneut versuchen.";
+        challengeFeedback.style.color = "var(--danger)";
+        markSuspicious("Falsche Antwort auf Challenge");
+        setTimeout(() => pickQuestion(), 600);
+        return;
+      }
+      if (responseTime < 1200) {
+        markSuspicious("Antwortgeschwindigkeit unnatürlich");
+      }
+      challengeFeedback.textContent = "Prüfung bestanden. Viel Spaß!";
+      challengeFeedback.style.color = "#16a34a";
+      setTimeout(() => {
+        hideOverlay();
+      }, 500);
+    });
+  }
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      markSuspicious("Tab wurde sofort wieder verlassen");
+    }
+  });
+
+  analyseBrowser();
+  setupInteractionWatchdog();
+  fetchServerStatus();
+  pickQuestion();
+})();
+    </script>
+  </body>
+</html>

--- a/web/support.html
+++ b/web/support.html
@@ -1,0 +1,425 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HumanShield – Support</title>
+    <style>
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  --accent: #2563eb;
+  --danger: #dc2626;
+  --surface: rgba(255, 255, 255, 0.86);
+  --surface-dark: rgba(17, 24, 39, 0.86);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e3a8a, #0f172a);
+  color: #f8fafc;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.site-header {
+  padding: 1.5rem 2rem;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-header nav {
+  display: flex;
+  gap: 1rem;
+  font-weight: 600;
+}
+
+.content {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 24px;
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.35);
+}
+
+.content h2,
+.content h3 {
+  color: #e0f2fe;
+}
+
+.content ul {
+  padding-left: 1.25rem;
+}
+
+.content details {
+  margin-bottom: 1rem;
+  background: rgba(30, 58, 138, 0.45);
+  padding: 1rem;
+  border-radius: 12px;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.78);
+  backdrop-filter: blur(4px);
+  transition: opacity 0.25s ease;
+  z-index: 999;
+}
+
+.overlay.hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.overlay-card {
+  width: min(420px, 90vw);
+  background: var(--surface);
+  color: #0f172a;
+  padding: 2rem;
+  border-radius: 16px;
+  box-shadow: 0 16px 48px rgba(15, 23, 42, 0.3);
+}
+
+@media (prefers-color-scheme: dark) {
+  .overlay-card {
+    background: var(--surface-dark);
+    color: #f1f5f9;
+  }
+}
+
+.overlay-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.overlay-card input {
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  font-size: 1rem;
+}
+
+.overlay-card button {
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  background: var(--accent);
+  color: white;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.overlay-card button:hover,
+.overlay-card button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 24px rgba(37, 99, 235, 0.4);
+}
+
+.alert {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 1.5rem;
+  margin-inline: auto;
+  width: min(480px, 90vw);
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+  background: rgba(220, 38, 38, 0.9);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
+  z-index: 1000;
+}
+
+.alert.hidden {
+  display: none;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+    </style>
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>HumanShield Support</h1>
+      <nav>
+        <a href="index.html">Start</a>
+        <a href="support.html" aria-current="page">Support</a>
+      </nav>
+    </header>
+
+    <main class="content" data-page-id="support">
+      <section>
+        <h2>Hilfe &amp; Dokumentation</h2>
+        <p>
+          Sollte die Bot-Prüfung ausgelöst werden, erscheint hier eine
+          Zusammenfassung aller erkannten Signale. Nutzen Sie die Informationen,
+          um Ihre Sicherheitsregeln weiter zu verfeinern.
+        </p>
+      </section>
+
+      <section>
+        <h3>Typische Fragen</h3>
+        <details>
+          <summary>Warum sehe ich ständig die Prüfung?</summary>
+          <p>
+            Browser im Automatisierungsmodus, fehlende Benutzerinteraktion oder
+            veraltete User-Agents sind häufige Ursachen. Passen Sie ggf. Ihre
+            Einstellungen an.
+          </p>
+        </details>
+        <details>
+          <summary>Wie erweitere ich die Server-Logik?</summary>
+          <p>
+            Bearbeiten Sie die Datei <code>bot_server.py</code>, um IP-Blocking
+            oder weitergehende Analysen einzubauen. Die Struktur ist modular und
+            kann leicht angepasst werden.
+          </p>
+        </details>
+      </section>
+    </main>
+
+    <div id="challenge-overlay" class="overlay hidden">
+      <div class="overlay-card">
+        <h2>Interaktionsprüfung</h2>
+        <p id="challenge-text"></p>
+        <form id="challenge-form">
+          <label class="visually-hidden" for="challenge-answer">Antwort</label>
+          <input
+            id="challenge-answer"
+            type="text"
+            name="answer"
+            autocomplete="off"
+            required
+          />
+          <button type="submit">Antwort prüfen</button>
+        </form>
+        <p id="challenge-feedback" aria-live="polite"></p>
+      </div>
+    </div>
+
+    <div id="alert-banner" class="alert hidden" role="alert"></div>
+    <script>
+(function () {
+  const overlay = document.getElementById("challenge-overlay");
+  const challengeText = document.getElementById("challenge-text");
+  const challengeForm = document.getElementById("challenge-form");
+  const challengeAnswer = document.getElementById("challenge-answer");
+  const challengeFeedback = document.getElementById("challenge-feedback");
+  const alertBanner = document.getElementById("alert-banner");
+  const pageId = document.querySelector("main.content")?.dataset.pageId ?? "unknown";
+
+  const suspiciousSignals = new Set();
+  let questionStart = performance.now();
+  let currentQuestion = null;
+  let hasReported = false;
+  let interactionDetected = false;
+
+  const questions = [
+    {
+      text: "Schreibe die letzten drei Buchstaben des Wortes 'Verifikation' rückwärts.",
+      validate: (answer) =>
+        answer.trim().toLowerCase() === "noitacifirev".slice(-3).split("").reverse().join(""),
+    },
+    {
+      text: "Welche Zahl ergibt 7×3 minus 4?",
+      validate: (answer) => Number.parseInt(answer, 10) === 17,
+    },
+    {
+      text: "Tippe das zweite Wort dieses Satzes: 'Bots lösen selten Rätsel'.",
+      validate: (answer) => answer.trim().toLowerCase() === "lösen",
+    },
+    {
+      text: "Gib die Summe der Zahlen 4, 6 und 9 an.",
+      validate: (answer) => Number.parseInt(answer, 10) === 19,
+    },
+    {
+      text: "Schreibe das Wort 'Mensch' ohne den ersten Buchstaben.",
+      validate: (answer) => answer.trim().toLowerCase() === "ensch",
+    },
+  ];
+
+  function showOverlay() {
+    overlay?.classList.remove("hidden");
+    challengeAnswer?.focus({ preventScroll: true });
+  }
+
+  function hideOverlay() {
+    overlay?.classList.add("hidden");
+    challengeFeedback.textContent = "";
+  }
+
+  function pickQuestion() {
+    currentQuestion = questions[Math.floor(Math.random() * questions.length)];
+    questionStart = performance.now();
+    if (challengeText) {
+      challengeText.textContent = currentQuestion.text;
+    }
+    challengeAnswer.value = "";
+    showOverlay();
+  }
+
+  function markSuspicious(reason) {
+    if (!reason || suspiciousSignals.has(reason)) {
+      return;
+    }
+    suspiciousSignals.add(reason);
+    alertBanner.textContent = `Verdächtiges Verhalten erkannt: ${reason}`;
+    alertBanner.classList.remove("hidden");
+    reportSuspicion();
+  }
+
+  async function reportSuspicion() {
+    if (hasReported || suspiciousSignals.size === 0) {
+      return;
+    }
+    hasReported = true;
+    try {
+      const response = await fetch("/report-bot", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          page: pageId,
+          reasons: Array.from(suspiciousSignals),
+          timestamp: new Date().toISOString(),
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`Server meldete Status ${response.status}`);
+      }
+    } catch (error) {
+      console.error("Bot-Report fehlgeschlagen", error);
+    }
+  }
+
+  function analyseBrowser() {
+    const ua = navigator.userAgent.toLowerCase();
+    if (!ua) {
+      markSuspicious("User-Agent fehlt");
+    }
+    const suspiciousTokens = ["bot", "spider", "crawler", "scrapy", "curl", "python"];
+    if (suspiciousTokens.some((token) => ua.includes(token))) {
+      markSuspicious("Verdächtiger User-Agent");
+    }
+    if (navigator.webdriver) {
+      markSuspicious("Webdriver aktiv");
+    }
+    if (!navigator.languages || navigator.languages.length === 0) {
+      markSuspicious("Keine Sprache konfiguriert");
+    }
+    if (window.outerWidth === 0 || window.outerHeight === 0) {
+      markSuspicious("Fenstergröße ungewöhnlich");
+    }
+    if (!("onmousemove" in window) && !("ontouchstart" in window)) {
+      markSuspicious("Keine Zeiger- oder Touch-Events");
+    }
+  }
+
+  function setupInteractionWatchdog() {
+    const interactionHandler = () => {
+      interactionDetected = true;
+      window.removeEventListener("mousemove", interactionHandler);
+      window.removeEventListener("touchstart", interactionHandler);
+      window.removeEventListener("keydown", interactionHandler);
+    };
+
+    window.addEventListener("mousemove", interactionHandler, { once: true });
+    window.addEventListener("touchstart", interactionHandler, { once: true });
+    window.addEventListener("keydown", interactionHandler, { once: true });
+
+    setTimeout(() => {
+      if (!interactionDetected) {
+        markSuspicious("Keine Benutzerinteraktion innerhalb von 8s");
+      }
+    }, 8000);
+  }
+
+  async function fetchServerStatus() {
+    try {
+      const response = await fetch("/bot-status");
+      if (!response.ok) {
+        return;
+      }
+      const payload = await response.json();
+      if (payload?.flagged) {
+        alertBanner.textContent = `Server meldet Verdacht: ${payload.reasons.join(", ")}`;
+        alertBanner.classList.remove("hidden");
+      }
+    } catch (error) {
+      console.warn("Status konnte nicht geladen werden", error);
+    }
+  }
+
+  if (challengeForm) {
+    challengeForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      if (!currentQuestion) {
+        return;
+      }
+      const responseTime = performance.now() - questionStart;
+      const answer = challengeAnswer.value;
+      if (!currentQuestion.validate(answer)) {
+        challengeFeedback.textContent = "Antwort falsch. Bitte erneut versuchen.";
+        challengeFeedback.style.color = "var(--danger)";
+        markSuspicious("Falsche Antwort auf Challenge");
+        setTimeout(() => pickQuestion(), 600);
+        return;
+      }
+      if (responseTime < 1200) {
+        markSuspicious("Antwortgeschwindigkeit unnatürlich");
+      }
+      challengeFeedback.textContent = "Prüfung bestanden. Viel Spaß!";
+      challengeFeedback.style.color = "#16a34a";
+      setTimeout(() => {
+        hideOverlay();
+      }, 500);
+    });
+  }
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      markSuspicious("Tab wurde sofort wieder verlassen");
+    }
+  });
+
+  analyseBrowser();
+  setupInteractionWatchdog();
+  fetchServerStatus();
+  pickQuestion();
+})();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- inline the shared styling and bot-detection script directly into index.html
- mirror the same inline assets in support.html so only two HTML files are required
- remove the now-unused css and js asset directories

## Testing
- python -m compileall bot_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d67998fc68832a841108278e6b4672