### PR TITLE
Serve conditional bot challenge from server

### DIFF
--- a/bot_server.py
+++ b/bot_server.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Kleiner HTTP-Server mit grundlegender Bot-Erkennung."""
+
+from __future__ import annotations
+
+import html
+import json
+import logging
+import textwrap
+import time
+from http import HTTPStatus
+from http.cookies import SimpleCookie
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from typing import Dict, List
+from urllib.parse import unquote
+
+BASE_DIR = Path(__file__).resolve().parent
+WEB_DIR = BASE_DIR / "web"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+)
+
+
+class SuspicionStore:
+    """Speichert Verdachtsfälle in Memory."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, List[str]]] = {}
+
+    def flag(self, client_id: str, reason: str) -> None:
+        bucket = self._store.setdefault(client_id, {"reasons": [], "ts": time.time()})
+        if reason not in bucket["reasons"]:
+            bucket["reasons"].append(reason)
+            bucket["ts"] = time.time()
+
+    def bulk_flag(self, client_id: str, reasons: List[str]) -> None:
+        for reason in reasons:
+            self.flag(client_id, reason)
+
+    def get(self, client_id: str) -> Dict[str, List[str]] | None:
+        entry = self._store.get(client_id)
+        if entry and time.time() - entry.get("ts", 0) > 3600:
+            # nach einer Stunde löschen
+            self._store.pop(client_id, None)
+            return None
+        return entry
+
+    def clear(self, client_id: str) -> None:
+        self._store.pop(client_id, None)
+
+
+SUSPICIOUS_TOKENS = ("bot", "spider", "crawler", "scrapy", "curl", "python")
+HEADLESS_HINTS = ("headless", "phantomjs", "selenium")
+
+
+class BotShieldHandler(SimpleHTTPRequestHandler):
+    suspicion_store = SuspicionStore()
+
+    def translate_path(self, path: str) -> str:
+        """Sicherstellen, dass nur Dateien aus dem Web-Ordner bedient werden."""
+        clean_path = unquote(path.split("?", 1)[0].split("#", 1)[0])
+        target = (WEB_DIR / clean_path.lstrip("/")).resolve()
+        if target.is_dir():
+            target = target / "index.html"
+        try:
+            target.relative_to(WEB_DIR)
+        except ValueError:
+            return str(WEB_DIR / "index.html")
+        if not target.exists():
+            return str(WEB_DIR / "index.html")
+        return str(target)
+
+    # pylint: disable=missing-docstring
+    def log_message(self, format: str, *args):  # type: ignore[override]
+        logging.info("%s - %s", self.client_address[0], format % args)
+
+    def end_headers(self):  # type: ignore[override]
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    def do_GET(self) -> None:  # type: ignore[override]
+        client_id = self.client_address[0]
+        if self.path == "/bot-status":
+            self._handle_status(client_id)
+            return
+        if self.path == "/human-verified":
+            self._handle_clear(client_id)
+            return
+
+        suspicious_reasons = self._analyse_request()
+        flagged_reasons: List[str] = []
+        if suspicious_reasons:
+            logging.warning("Verdächtige Anfrage von %s: %s", client_id, suspicious_reasons)
+            self.suspicion_store.bulk_flag(client_id, suspicious_reasons)
+            flagged_reasons.extend(suspicious_reasons)
+
+        stored = self.suspicion_store.get(client_id)
+        if stored:
+            for reason in stored["reasons"]:
+                if reason not in flagged_reasons:
+                    flagged_reasons.append(reason)
+
+        if flagged_reasons:
+            self._serve_with_challenge(flagged_reasons)
+            return
+
+        super().do_GET()
+
+    def do_POST(self) -> None:  # type: ignore[override]
+        client_id = self.client_address[0]
+        if self.path == "/report-bot":
+            self._handle_report(client_id)
+            return
+        if self.path == "/human-verified":
+            self._handle_clear(client_id)
+            return
+
+        self.send_error(HTTPStatus.NOT_FOUND, "Unbekannte Ressource")
+
+    # Hilfsfunktionen -----------------------------------------------------
+
+    def _analyse_request(self) -> List[str]:
+        reasons: List[str] = []
+        user_agent = (self.headers.get("User-Agent") or "").lower()
+        if not user_agent:
+            reasons.append("Kein User-Agent")
+        else:
+            if any(token in user_agent for token in SUSPICIOUS_TOKENS):
+                reasons.append("User-Agent enthält Bot-Tokens")
+            if any(token in user_agent for token in HEADLESS_HINTS):
+                reasons.append("Headless-Indiz im User-Agent")
+        if not self.headers.get("Accept-Language"):
+            reasons.append("Keine Accept-Language gesetzt")
+        fetch_site = self.headers.get("Sec-Fetch-Site")
+        if fetch_site == "none":
+            reasons.append("Fehlender Kontext (Sec-Fetch-Site: none)")
+        if self.headers.get("X-Forwarded-For"):
+            reasons.append("Proxy/Forwarded Header gesetzt")
+        return reasons
+
+    def _serve_with_challenge(self, reasons: List[str]) -> None:
+        path = Path(self.translate_path(self.path))
+        if path.is_dir():
+            path = path / "index.html"
+        if not path.exists():
+            path = WEB_DIR / "index.html"
+
+        try:
+            html_content = path.read_text("utf-8")
+        except OSError as exc:
+            logging.error("Konnte Datei %s nicht lesen: %s", path, exc)
+            self.send_error(HTTPStatus.INTERNAL_SERVER_ERROR, "Datei konnte nicht gelesen werden")
+            return
+
+        injected = self._inject_challenge(html_content, reasons)
+        encoded_body = injected.encode("utf-8")
+        cookie = SimpleCookie()
+        cookie["bot_flagged"] = "1"
+        cookie["bot_flagged"]["path"] = "/"
+
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded_body)))
+        for morsel in cookie.values():
+            self.send_header("Set-Cookie", morsel.OutputString())
+        self.end_headers()
+        self.wfile.write(encoded_body)
+
+    def _handle_status(self, client_id: str) -> None:
+        stored = self.suspicion_store.get(client_id)
+        payload = {"flagged": False, "reasons": []}
+        if stored:
+            payload["flagged"] = True
+            payload["reasons"] = stored["reasons"]
+        cookie_header = self.headers.get("Cookie")
+        if cookie_header:
+            cookie = SimpleCookie()
+            cookie.load(cookie_header)
+            if cookie.get("bot_flagged"):
+                payload.setdefault("cookies", {})
+                payload["cookies"]["bot_flagged"] = cookie["bot_flagged"].value
+
+        response = json.dumps(payload)
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response.encode("utf-8"))
+
+    def _handle_report(self, client_id: str) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = self.rfile.read(length).decode("utf-8") if length else "{}"
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Ungültiges JSON")
+            return
+
+        reasons = data.get("reasons") or []
+        if isinstance(reasons, list):
+            for reason in reasons:
+                if isinstance(reason, str) and reason.strip():
+                    self.suspicion_store.flag(client_id, reason.strip())
+        logging.warning("Client %s meldete verdächtiges Verhalten: %s", client_id, reasons)
+
+        self._write_json({"status": "received"})
+
+    def _handle_clear(self, client_id: str) -> None:
+        self.suspicion_store.clear(client_id)
+        cookie = SimpleCookie()
+        cookie["bot_flagged"] = "0"
+        cookie["bot_flagged"]["path"] = "/"
+        cookie["bot_flagged"]["max-age"] = "0"
+        payload = {"status": "cleared"}
+        encoded = json.dumps(payload)
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        for morsel in cookie.values():
+            self.send_header("Set-Cookie", morsel.OutputString())
+        self.end_headers()
+        self.wfile.write(encoded.encode("utf-8"))
+
+    def _write_json(self, payload: Dict[str, object]) -> None:
+        encoded = json.dumps(payload)
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded.encode("utf-8"))
+
+    def _inject_challenge(self, html_content: str, reasons: List[str]) -> str:
+        reasons_json = json.dumps(reasons, ensure_ascii=False)
+        reasons_html = "".join(
+            f"<li>{html.escape(reason)}</li>" for reason in reasons
+        )
+        snippet = textwrap.dedent(
+            f"""
+            <div id="bot-challenge-overlay" class="bot-challenge-overlay" role="dialog" aria-modal="true">
+              <div class="bot-challenge-card">
+                <h1>Verdachtsprüfung</h1>
+                <p>Unser System hat Auffälligkeiten entdeckt. Bitte beantworte die Frage, um fortzufahren.</p>
+                <div class="bot-reasons">
+                  <strong>Gründe:</strong>
+                  <ul>
+                    {reasons_html}
+                  </ul>
+                </div>
+                <form class="bot-challenge-form">
+                  <label for="bot-answer">Frage:</label>
+                  <div class="bot-question" data-role="question"></div>
+                  <input id="bot-answer" name="answer" type="text" placeholder="Antwort eingeben" autocomplete="off" required />
+                  <button type="submit">Bestätigen</button>
+                  <p class="bot-feedback" data-role="feedback" aria-live="polite"></p>
+                </form>
+              </div>
+            </div>
+            <style>
+              .bot-challenge-overlay {{
+                position: fixed;
+                inset: 0;
+                background: rgba(15, 23, 42, 0.92);
+                display: grid;
+                place-items: center;
+                z-index: 2147483000;
+                backdrop-filter: blur(4px);
+              }}
+              .bot-challenge-card {{
+                width: min(560px, 90vw);
+                background: linear-gradient(165deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.98));
+                padding: 2.5rem;
+                border-radius: 24px;
+                box-shadow: 0 30px 90px rgba(8, 47, 73, 0.6);
+                color: #e2e8f0;
+                display: grid;
+                gap: 1.4rem;
+              }}
+              .bot-challenge-card h1 {{
+                margin: 0;
+                font-size: clamp(2rem, 4vw, 2.5rem);
+              }}
+              .bot-reasons ul {{
+                padding-left: 1.25rem;
+                margin: 0.75rem 0 0;
+              }}
+              .bot-challenge-form {{
+                display: grid;
+                gap: 0.75rem;
+              }}
+              .bot-challenge-form input {{
+                padding: 0.75rem 1rem;
+                border-radius: 12px;
+                border: 1px solid rgba(148, 163, 184, 0.4);
+                background: rgba(15, 23, 42, 0.6);
+                color: inherit;
+                font-size: 1rem;
+              }}
+              .bot-challenge-form button {{
+                padding: 0.75rem 1.2rem;
+                border-radius: 12px;
+                border: none;
+                background: linear-gradient(135deg, #38bdf8, #2563eb);
+                color: white;
+                font-weight: 600;
+                cursor: pointer;
+                transition: transform 0.2s ease, box-shadow 0.2s ease;
+              }}
+              .bot-challenge-form button:hover,
+              .bot-challenge-form button:focus {{
+                transform: translateY(-1px);
+                box-shadow: 0 20px 45px rgba(37, 99, 235, 0.35);
+              }}
+              .bot-feedback {{
+                min-height: 1.25rem;
+                color: #f97316;
+                font-weight: 600;
+              }}
+            </style>
+            <script id="bot-challenge-script" data-reasons='{reasons_json}'>
+              (() => {{
+                const script = document.getElementById('bot-challenge-script');
+                const overlay = document.getElementById('bot-challenge-overlay');
+                if (!script || !overlay) return;
+
+                const questionBox = overlay.querySelector('[data-role="question"]');
+                const feedback = overlay.querySelector('[data-role="feedback"]');
+                const form = overlay.querySelector('.bot-challenge-form');
+                const input = overlay.querySelector('#bot-answer');
+
+                const questions = [
+                  {{ q: 'Wie viele Buchstaben hat das Wort "Mensch"?', a: '6' }},
+                  {{ q: 'Was ergibt 7 + 5?', a: '12' }},
+                  {{ q: 'Welcher Wochentag folgt auf Montag?', a: 'dienstag' }},
+                  {{ q: 'Schreibe das Wort "Sonne" rückwärts.', a: 'ennos' }},
+                  {{ q: 'Wie heißt die Hauptstadt von Deutschland?', a: 'berlin' }}
+                ];
+
+                const current = questions[Math.floor(Math.random() * questions.length)];
+                if (questionBox) {{
+                  questionBox.textContent = current.q;
+                }}
+
+                const markSolved = async () => {{
+                  try {{
+                    await fetch('/human-verified', {{
+                      method: 'POST',
+                      headers: {{ 'Content-Type': 'application/json' }},
+                      body: JSON.stringify({{ cleared: true, question: current.q }})
+                    }});
+                  }} catch (err) {{
+                    console.warn('Konnte Status nicht senden', err);
+                  }}
+                }};
+
+                form?.addEventListener('submit', async (event) => {{
+                  event.preventDefault();
+                  const value = (input?.value || '').trim().toLowerCase();
+                  if (!value) {{
+                    feedback.textContent = 'Bitte gib eine Antwort ein.';
+                    return;
+                  }}
+                  if (value === current.a) {{
+                    feedback.textContent = 'Danke! Der Verdacht wurde aufgehoben.';
+                    await markSolved();
+                    setTimeout(() => overlay.remove(), 600);
+                  }} else {{
+                    feedback.textContent = 'Das war leider falsch. Versuche es erneut.';
+                    input?.focus();
+                  }}
+                }});
+
+                input?.focus();
+              }})();
+            </script>
+            """
+        )
+
+        if "</body>" in html_content:
+            return html_content.replace("</body>", snippet + "</body>")
+        return html_content + snippet
+
+
+def run(server_class=HTTPServer, handler_class=BotShieldHandler) -> None:
+    server_address = ("0.0.0.0", 8080)
+    httpd = server_class(server_address, handler_class)
+    logging.info("BotShield-Server läuft auf http://%s:%s", *server_address)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        logging.info("Server wird beendet ...")
+    finally:
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    run()

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HumanShield – Startseite</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+        line-height: 1.6;
+        --accent: #2563eb;
+        --surface: rgba(255, 255, 255, 0.9);
+        --surface-dark: rgba(15, 23, 42, 0.85);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, #1e3a8a, #0f172a);
+        color: #f8fafc;
+        display: flex;
+        flex-direction: column;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      a:hover,
+      a:focus {
+        text-decoration: underline;
+      }
+
+      header {
+        padding: 1.5rem 2rem;
+        background: rgba(15, 23, 42, 0.85);
+        backdrop-filter: blur(8px);
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      header nav {
+        display: flex;
+        gap: 1.5rem;
+        font-weight: 600;
+      }
+
+      main {
+        flex: 1 1 auto;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+      }
+
+      .card {
+        width: min(720px, 100%);
+        border-radius: 24px;
+        padding: clamp(2rem, 5vw, 3rem);
+        background: var(--surface-dark);
+        box-shadow: 0 30px 80px rgba(8, 47, 73, 0.6);
+      }
+
+      .card h1 {
+        margin-top: 0;
+        margin-bottom: 1rem;
+        font-size: clamp(2.3rem, 5vw, 3.2rem);
+      }
+
+      .card p {
+        margin-bottom: 1.25rem;
+        color: rgba(226, 232, 240, 0.9);
+      }
+
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.85rem 1.4rem;
+        border-radius: 999px;
+        background: linear-gradient(135deg, #2563eb, #38bdf8);
+        color: white;
+        font-weight: 600;
+        box-shadow: 0 20px 40px rgba(37, 99, 235, 0.35);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .cta:hover,
+      .cta:focus {
+        transform: translateY(-2px);
+        box-shadow: 0 24px 60px rgba(37, 99, 235, 0.45);
+      }
+
+      footer {
+        padding: 1.5rem 2rem;
+        text-align: center;
+        background: rgba(15, 23, 42, 0.75);
+        color: rgba(226, 232, 240, 0.75);
+      }
+
+      @media (max-width: 600px) {
+        header nav {
+          width: 100%;
+          justify-content: center;
+        }
+
+        .cta {
+          width: 100%;
+          justify-content: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>
+        <strong>HumanShield</strong>
+      </div>
+      <nav>
+        <a href="/index.html">Start</a>
+        <a href="/support.html">Support</a>
+      </nav>
+    </header>
+    <main>
+      <article class="card">
+        <h1>Schütze deine Plattform vor Bots</h1>
+        <p>
+          HumanShield hilft dir dabei, verdächtige Zugriffe im Hintergrund zu
+          erkennen. Deine eigentliche Seite bleibt unverändert – nur wenn unser
+          Server Auffälligkeiten feststellt, erscheint ein zusätzlicher Check.
+        </p>
+        <p>
+          Starte den Python-Server und rufe deine bestehenden Seiten ganz
+          normal auf. Der Schutz greift automatisch, sobald ein verdächtiger
+          Aufruf erkannt wird.
+        </p>
+        <a class="cta" href="/support.html">Mehr erfahren</a>
+      </article>
+    </main>
+    <footer>© 2024 HumanShield – Intelligenter Bot-Schutz</footer>
+  </body>
+</html>

--- a/web/support.html
+++ b/web/support.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HumanShield – Support</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+        line-height: 1.6;
+        --accent: #38bdf8;
+        --surface: rgba(255, 255, 255, 0.92);
+        --surface-dark: rgba(15, 23, 42, 0.85);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: linear-gradient(160deg, #0f172a, #1e293b 40%, #0f172a 100%);
+        color: #f8fafc;
+        display: flex;
+        flex-direction: column;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      header {
+        padding: 1.5rem 2rem;
+        background: rgba(15, 23, 42, 0.85);
+        backdrop-filter: blur(8px);
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      header nav {
+        display: flex;
+        gap: 1.5rem;
+        font-weight: 600;
+      }
+
+      main {
+        flex: 1 1 auto;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+      }
+
+      .panel {
+        width: min(820px, 100%);
+        border-radius: 24px;
+        padding: clamp(2rem, 5vw, 3.5rem);
+        background: var(--surface-dark);
+        box-shadow: 0 30px 80px rgba(8, 47, 73, 0.5);
+      }
+
+      h1 {
+        margin: 0 0 1rem;
+        font-size: clamp(2.2rem, 4vw, 3rem);
+      }
+
+      section + section {
+        margin-top: 2rem;
+        border-top: 1px solid rgba(148, 163, 184, 0.3);
+        padding-top: 2rem;
+      }
+
+      ul {
+        margin: 0 0 1.5rem 1.25rem;
+        color: rgba(226, 232, 240, 0.9);
+      }
+
+      code {
+        background: rgba(15, 23, 42, 0.65);
+        padding: 0.2rem 0.45rem;
+        border-radius: 6px;
+        font-size: 0.95em;
+      }
+
+      footer {
+        padding: 1.5rem 2rem;
+        text-align: center;
+        background: rgba(15, 23, 42, 0.75);
+        color: rgba(226, 232, 240, 0.75);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>
+        <strong>HumanShield</strong>
+      </div>
+      <nav>
+        <a href="/index.html">Start</a>
+        <a href="/support.html">Support</a>
+      </nav>
+    </header>
+    <main>
+      <article class="panel">
+        <h1>Support &amp; Integration</h1>
+        <section>
+          <h2>So funktioniert der Schutz</h2>
+          <p>
+            Dein HTML muss nicht angepasst werden. Der Python-Server untersucht
+            eingehende Requests und blendet nur bei Auffälligkeiten eine
+            zusätzliche Prüfung in die ausgelieferte Seite ein.
+          </p>
+          <ul>
+            <li>Verdächtige Header wie fehlende Sprache oder Bot-User-Agents</li>
+            <li>IP-basierte Auffälligkeiten werden gespeichert</li>
+            <li>Manuelle Meldungen an <code>/report-bot</code> sind möglich</li>
+          </ul>
+        </section>
+        <section>
+          <h2>In Betrieb nehmen</h2>
+          <ol>
+            <li><code>python bot_server.py</code> starten</li>
+            <li>Deine bestehenden Seiten wie gewohnt aufrufen</li>
+            <li>
+              Bei Verdacht erscheint eine Challenge mit Fragen, die Bots kaum
+              beantworten können. Erfolgreiche Prüfungen heben den Verdacht auf.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h2>API-Endpunkte</h2>
+          <ul>
+            <li><code>GET /bot-status</code> – aktueller Verdachtsstatus</li>
+            <li><code>POST /report-bot</code> – Verdacht von Clients melden</li>
+            <li><code>POST /human-verified</code> – Challenge erfolgreich</li>
+          </ul>
+        </section>
+      </article>
+    </main>
+    <footer>Fragen? Schreibe uns an support@humanshield.dev</footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- inject the bot-verification overlay from the Python server only when a request is flagged as suspicious
- provide endpoints to clear stored suspicion and reuse existing pages without manual script updates
- simplify the HTML pages to static content so the server can add challenges automatically when needed

## Testing
- python -m compileall bot_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d67998fc68832a841108278e6b4672